### PR TITLE
CIRC-8337: Add points field to SeriesOverride type

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -404,6 +404,7 @@ type (
 		Legend        *bool       `json:"legend,omitempty"`
 		Lines         *bool       `json:"lines,omitempty"`
 		LineWidth     *int        `json:"linewidth,omitempty"`
+		Points        *bool       `json:"points,omitempty"`
 		Stack         *BoolString `json:"stack,omitempty"`
 		Transform     *string     `json:"transform,omitempty"`
 		YAxis         *int        `json:"yaxis,omitempty"`


### PR DESCRIPTION
* fix: Adds a points field to the SeriesOverride type to prevent dropping this from panels.